### PR TITLE
Changed page indicator color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Changed the color of the page indicator on the issues page from gray-300 to gray-700 to match figma designs